### PR TITLE
fix clear recent emojis not working

### DIFF
--- a/src/components/picker/nimble-picker.js
+++ b/src/components/picker/nimble-picker.js
@@ -315,6 +315,10 @@ export default class NimblePicker extends React.PureComponent {
   }
 
   onClearAllClickHandler() {
+    var component = this.categoryRefs['category-1'];
+    if (component) {
+      component.forceUpdate();
+    }
     this.props.onClearAllClick();
     frequently.removeAll();
   }


### PR DESCRIPTION
Even after clearing the component state as well as localStorage, the recent emojis were not clearing up. But after clicking clear-all and then selecting an emoji, it was resulting in that one particular emoji being shown in recent.
So I made a change to force reload the recent emoji component when user click clear all. Please have a look